### PR TITLE
require promise library before each connection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,10 @@ exports.register = function (plugin, pluginOptions, next) {
 
         var connect = function (connectionOptions, done) {
 
+            if (connectionOptions.settings && typeof connectionOptions.settings.promiseLibrary === 'string') {
+                connectionOptions.settings.promiseLibrary = require(connectionOptions.settings.promiseLibrary);
+            }
+
             MongoClient.connect(connectionOptions.url, connectionOptions.settings, function (err, db) {
 
                 if (err) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "async": "^1.4.2",
+    "bluebird": "^3.0.2",
     "joi": "^6.0.8",
     "mongodb": "^2.0.25"
   },

--- a/test/connection.js
+++ b/test/connection.js
@@ -143,4 +143,20 @@ describe('Hapi server', function () {
             done();
         });
     });
+    it('should require the "promiseLibrary" before passing it to mongodb', function (done) {
+
+        server.register({
+            register: require('../'),
+            options: {
+                settings: {
+                    promiseLibrary: 'bluebird'
+                }
+            }
+        }, function (err) {
+
+            expect(err).to.not.exist();
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Hi, i modified a little bit the plugin, in order to use the *promiseLibrary* setting of MongoClient.connect (which require the Promise class of the library), with hapi json manifest, ex:

    {"hapi-mongodb": [{
      "select": ["api"],
      "options": {
        "url": "mongodb://localhost:27017/db",
        "settings": {
          "promiseLibrary": "bluebird"
        }
      }
    }]}

