### PR TITLE
Upgrade hapi-related dependencies to reflect their move to a new namespace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Mongodb = require('mongodb');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const MongoClient = Mongodb.MongoClient;
 const ObjectID = Mongodb.ObjectID;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-mongodb",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "A simple Hapi MongoDB connection plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-mongodb",
-  "version": "9.0.0",
+  "version": "8.0.0",
   "description": "A simple Hapi MongoDB connection plugin.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple Hapi MongoDB connection plugin.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "lab -M 5000 -t 100 -a code -L"
+    "test": "lab -M 5000 -t 100 -a @hapi/code -L"
   },
   "repository": {
     "type": "git",
@@ -22,17 +22,17 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "joi": "14.x.x",
-    "mongodb": "^3.1.8"
+    "@hapi/joi": "^15.0.0",
+    "mongodb": "^3.2.3"
   },
   "devDependencies": {
-    "bluebird": "3.x.x",
-    "code": "5.x.x",
-    "hapi": ">= 17.x.x",
-    "hoek": "5.x.x",
-    "lab": "17.x.x"
+    "@hapi/code": "^5.3.1",
+    "@hapi/hapi": ">= 18.0.0",
+    "@hapi/hoek": "^6.2.1",
+    "@hapi/lab": "^18.1.2",
+    "bluebird": "3.x.x"
   },
   "peerDependencies": {
-    "hapi": ">= 17.x.x"
+    "@hapi/hapi": ">= 18.0.0"
   }
 }

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Hapi = require('hapi');
-const Hoek = require('hoek');
-const Lab = require('lab');
+const Hapi = require('@hapi/hapi');
+const Hoek = require('@hapi/hoek');
+const Lab = require('@hapi/lab');
 const Mongodb = require('mongodb');
 
 const { describe, it, beforeEach, expect } = exports.lab = Lab.script();


### PR DESCRIPTION
Hapi itself and a lot of their modules moved to a namespace (@hapi).