### PR TITLE
log error from server stop event only if err is truthy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,7 +77,11 @@ exports.plugin = {
 
             for (const client of [].concat(expose.client)) {
 
-                client.close((err) => server.log(['hapi-mongodb', 'error'], err));
+                client.close((err) => {
+                    if(err) {
+                        server.log(['hapi-mongodb', 'error'], err));
+                    }
+                }
             }
         });
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-mongodb",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "A simple Hapi MongoDB connection plugin.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
The current version would log `err` when server stops. Problem is when `err` is not truthy, a blank log entry is emitted through `server.log`.