### PR TITLE
(bugfix): fix regex for connection string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.plugin = {
             const client = await MongoClient.connect(connectionOptions.url, connectionOptions.settings);
             const db = await client.db();
             const connectionOptionsToLog = Object.assign({}, connectionOptions, {
-                url: connectionOptions.url.replace( /mongodb:\/\/([^/]+):([^@]+)@/, 'mongodb://$1:******@')
+                url: connectionOptions.url.replace( /mongodb:\/\/([^/]+?):([^@]+)@/, 'mongodb://$1:******@')
             });
 
             server.log(['hapi-mongodb', 'info'], 'MongoClient connection created for ' + JSON.stringify(connectionOptionsToLog));


### PR DESCRIPTION
The problem:

For Azure's Comosdb (Mongodb instance), it has following format of connection string:

```
mongodb://user:abcdfg@example.com:10255/?ssl=true&appName=@user@
```
The console log output will be:

```
"mongodb://user:abcdfg@example.com:******@user@"
```

To apply a non-greedy which fix the issue:

```
"mongodb://user:******@example.com:10255/?ssl=true&appName=@user@"
```

This works for original connection strings.

sandbox link: https://codesandbox.io/s/loving-swanson-g907o?file=/src/index.js
