### PR TITLE
Adds obfuscation support for the DNS Seed List Connection Format (+srv)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.plugin = {
             const client = await MongoClient.connect(connectionOptions.url, connectionOptions.settings);
             const db = await client.db();
             const connectionOptionsToLog = Object.assign({}, connectionOptions, {
-                url: connectionOptions.url.replace( /mongodb:\/\/([^/]+?):([^@]+)@/, 'mongodb://$1:******@')
+                url: connectionOptions.url.replace( /mongodb(?:\+srv)?:\/\/([^/]+?):([^@]+)@/, 'mongodb://$1:******@')
             });
 
             server.log(['hapi-mongodb', 'info'], 'MongoClient connection created for ' + JSON.stringify(connectionOptionsToLog));


### PR DESCRIPTION
# Tasks:
- [ ] Check and improve replacement in the output. Despite the regex being valid (regexr.com/6ceak), it omits the `+srv` in the log output.

# Added value:
- Obfuscates connection strings in the DNS Seed List Connection Format (+srv)

# PR dependency:
- none